### PR TITLE
Aanzet voor vertaalregels OAS vanuit UML en vanuit DSO strategie regels

### DIFF
--- a/BSM naar OAS regels.md
+++ b/BSM naar OAS regels.md
@@ -169,8 +169,8 @@ type: integer
 minimum: {Minimum waarde (inclusief)}
 maximum: {Maximum waarde (inclusief)}
 ```
-__ISSUE__: Willen we format int32 of int64 opnemen? Moet (kan) dan worden afgeleid uit [n]?
-__ISSUE__: Is er in OAS een manier om maximale lengte [n] van string af te dwingen?
+__AANNAME__: We maken geen onderscheid in format int32 of int64.
+__AANNAME__: Maximale lengte [n] van integer hoeft (en kan?) niet te worden afgedwongen in schema
 
 ### N[n],[d]
 Minimum waarde (inclusief)
@@ -192,4 +192,4 @@ type: string
 type: string
 format: uri
 ```
-__ISSUE__: Hoe gaan we URI opnemen? Als zelf gedefinieerd format: uri? En/of met pattern?
+__AANNAME__: Verdere uitwerking (bijvoorbeeld pattern voor uri) is niet nodig

--- a/BSM naar OAS regels.md
+++ b/BSM naar OAS regels.md
@@ -3,12 +3,13 @@ Dit document beschrijft een aantal regels voor het vertalen van een bericht stru
 
 ## Subtypen
 Een entiteittype die een subtype is van een ander entiteittype wordt afgeleid met allOf:
-
+```
 allOf:
 	- $ref: '#/components/schemas/{supertype-componentnaam'
 	- type: object
 	  properties:
       {elementen van het subtype}
+```
 
 Bijvoorbeeld:
 ```

--- a/BSM naar OAS regels.md
+++ b/BSM naar OAS regels.md
@@ -1,0 +1,195 @@
+# Vertaling van BSM naar OAS
+Dit document beschrijft een aantal regels voor het vertalen van een bericht structuur model naar Open API Specificaties 3.0.
+
+## Subtypen
+Een entiteittype die een subtype is van een ander entiteittype wordt afgeleid met allOf:
+
+allOf:
+	- $ref: '#/components/schemas/{supertype-componentnaam'
+	- type: object
+	  properties:
+      {elementen van het subtype}
+
+Bijvoorbeeld:
+```
+natuurlijkPersonen:
+  type: object
+  description: Een PERSOON zijnde een mens.
+  properties:
+    academischeTitel:
+      $ref: '#/components/schemas/academischeTitel'
+    omschrijvingAcademischeTitel:
+      type: string
+      description: De omschrijving behorende bij NEN-tabel 'Academische titelcode'.
+      maxLength: 80
+      example: dr
+ingeschrevenNatuurlijkPersonen:
+  allOf: '#/components/schemas/natuurlijkPersonen'
+  type: object
+  description: Een NATUURLIJK PERSOON ingeschreven in de Basisregistratie Personen (BRP).
+  required:
+    - burgerservicenummer
+  properties:
+    burgerservicenummer:
+      type: integer
+      description: Het burgerservicenummer, bedoeld in artikel 1.1 van de Wet algemene bepalingen burgerservicenummer.
+      example: 999999138
+    burgerlijkeStaat:
+      type: string
+      enum:
+        - onbekend
+        - ongehuwd en nooit gehuwd geweest
+        - gehuwd
+        - gescheiden
+```
+
+## Required
+Onder required worden alle elementen opgenomen met [Mogelijk geen waarde] == Nee.
+
+Bijvoorbeeld:
+```
+required:
+  - stemmingsidentificatie
+  - stemmingstype
+  - eindresultaat
+```
+
+## Properties
+Bij de vertaling van properties van een object zijn op een aantal plekken aannames gedaan over de vertaling. Hierbij is geprobeerd de specificaties en implementatie daarvan zo eenvoudig mogelijk te houden. De gewenste vertaling moet dan worden bepaald in een koppelvlakproject op basis van businessbehoefte en optimalisering voor implementatie.
+
+Elk element wordt opgenomen met minimaal type, description (uit notes) en example (als die er is).
+
+__ISSUE__: Sommige elementnamen bevatten punt, maar DSO gebruikt punt (expand, fields, sortering) voor properties in gegevensgroep, relatie, enz.
+__ISSUE__: Hoe komen we aan voorbeeldwaarden (example)? Is daar al tagged value voor in MIM? Zijn er al voorbeeldwaarden opgenomen in UGM (of doen we dat altijd pas op BSM niveau)?
+
+### Enumeratiesoort
+```
+type: string
+enum:
+	- {enumeratie waarde}
+	- {volgende enumeratie waarde}
+```
+In parameters worden enumeratiewaarden opgenomen als [waarde1, waarde2, waarde3]
+
+### Complex datatype
+```
+$ref: '#/components/schemas/{complexdatatype-componentnaam}'
+```
+
+
+### Gegevensgroep
+```
+$ref: '#/components/schemas/{gegevensgroep-componentnaam}'
+```
+
+### Tabel-entiteit
+Element opnemen in \_embedded
+
+### Interface: NEN3610ID
+```
+$ref: '#/components/schemas/NEN3610'
+```
+
+### Extern interface: gml
+Element opnemen in \_embedded
+
+### Union
+Waarschuwing geven in Imvertor
+
+### Relatie
+Element opnemen in \_embedded
+
+### DATUM
+```
+type: string
+format: date
+```
+
+### DATUM?
+```
+type: string
+format: date
+nullable: true
+```
+
+### JAAR
+```
+type: integer
+maximum: 9999
+```
+
+### JAARMAAND
+```
+type: integer
+maximum: 999999
+```
+
+### DT
+```
+type: string
+format: date-time
+```
+
+### DT?
+```
+type: string
+format: date-time
+nullable: true
+```
+
+### POSTCODE
+```
+type: string
+pattern: ^[1-9]{1}[0-9]{3}[A-Z]{2}$
+```
+
+
+### INDIC
+```
+type: boolean
+```
+
+### AN, AN[x]
+Formeel patroon
+Minimum lengte
+
+```
+type: string
+pattern: ^{Formeel patroon}$
+minLength: {Minimum lengte}
+maxLength: {x}
+```
+
+### N, N[n]
+Minimum waarde (inclusief)
+Maximum waarde (inclusief)
+
+```
+type: integer
+minimum: {Minimum waarde (inclusief)}
+maximum: {Maximum waarde (inclusief)}
+```
+__ISSUE__: Willen we format int32 of int64 opnemen? Moet (kan) dan worden afgeleid uit [n]?
+__ISSUE__: Is er in OAS een manier om maximale lengte [n] van string af te dwingen?
+
+### N[n],[d]
+Minimum waarde (inclusief)
+Maximum waarde (inclusief)
+
+```
+type: number
+minimum: {Minimum waarde (inclusief)}
+maximum: {Maximum waarde (inclusief)}
+```
+
+### TXT
+```
+type: string
+```
+
+### URI
+```
+type: string
+format: uri
+```
+__ISSUE__: Hoe gaan we URI opnemen? Als zelf gedefinieerd format: uri? En/of met pattern?

--- a/BSM naar OAS regels.md
+++ b/BSM naar OAS regels.md
@@ -60,6 +60,7 @@ Bij de vertaling van properties van een object zijn op een aantal plekken aannam
 Elk element wordt opgenomen met minimaal type, description (uit notes) en example (als die er is).
 
 __ISSUE__: Sommige elementnamen bevatten punt, maar DSO gebruikt punt (expand, fields, sortering) voor properties in gegevensgroep, relatie, enz.
+
 __ISSUE__: Hoe komen we aan voorbeeldwaarden (example)? Is daar al tagged value voor in MIM? Zijn er al voorbeeldwaarden opgenomen in UGM (of doen we dat altijd pas op BSM niveau)?
 
 ### Enumeratiesoort
@@ -83,7 +84,7 @@ $ref: '#/components/schemas/{gegevensgroep-componentnaam}'
 ```
 
 ### Tabel-entiteit
-Element opnemen in \_embedded
+Opnemen als 'normale' property, met type afgeleid van sleutel van de tabel-entiteit.
 
 ### Interface: NEN3610ID
 ```
@@ -109,8 +110,9 @@ format: date
 ```
 type: string
 format: date
-nullable: true
 ```
+
+__VRAAG__: Hebben we al iets voor onvolledige datum in JSON (niet-StUF) berichten?
 
 ### JAAR
 ```
@@ -134,7 +136,6 @@ format: date-time
 ```
 type: string
 format: date-time
-nullable: true
 ```
 
 ### POSTCODE

--- a/OAS API onderlaagregels.md
+++ b/OAS API onderlaagregels.md
@@ -14,6 +14,7 @@
 > "versie" begint met "v" gevolgd door alleen het major versienummer (API-24)
 
 > "collectie" is een entiteittype (zelfstandig naamwoord) in meervoud (API-08)
+
 __ISSUE__: Hoe vertalen we entiteittype die in UGM in enkelvoud staan (t.b.v. StUF) naar meervoud (t.b.v. API's)?
 
 > uri-parameter "sleutel" moet voorkomen in parameters met "in: path"
@@ -90,8 +91,6 @@ Dus niet als een query parameter
 
 > Een JSON-response heeft geen omhullende envelop (API-32).
 
-  Er wordt dus geen element opgenomen voor het entiteittype (zoals in StUF wel gebruikelijk is).
-
 > Verschillende contentserialisaties kunnen worden ondersteund: JSON, GeoJSON, JSON+HAL, XML, enz.
 
 > In de JSON+HAL response content body is een element "\_links" opgenomen.
@@ -109,7 +108,11 @@ __ISSUE__: Kunnen we aangeven of er historie moet worden worden opgenomen? Kan d
 > GeoJSON is onderdeel van de embedded resource in de JSON response (API-39).
 
 ### Relaties
+Wordt opgenomen in \_embedded.
+Naast de properties van de relatie/gerelateerde wordt in het geval van JSON+HAL ook een \_links property opgenomen met daarin alleen property \_self (die weer de properties href en title bevat).
+
 __ISSUE__: Hoe gaan we om met relatie-entiteiten?
+
 __ISSUE__: Hoe gaan we ermee om als er geen relatie-entiteit is, maar wel historie op de relatie?
 
 ## Response content (400 reeks statuscodes)

--- a/OAS API onderlaagregels.md
+++ b/OAS API onderlaagregels.md
@@ -1,0 +1,118 @@
+# Regels Open API specificatie voor gemeentelijke API koppelvlakstandaarden
+
+## Algemeen
+> Definitie van het koppelvlak is in het Nederlands tenzij er sprake is van een officieel Engelstalig begrippenkader (API-07, API-20)
+
+## Paths
+* voor een lijstopvraging: /versie/collectie
+  Bijvoorbeeld: /v1/natuurlijkPersonen
+* voor een enkel voorkomen: /versie/collectie/{sleutel}
+  Bijvoorbeeld: /v1/natuurlijkPersonen/9991234567
+* voor terugkerende queries: /versie/collectie/query
+  Bijvoorbeeld: /v1/natuurlijkPersonen/minderjarigen
+
+> "versie" begint met "v" gevolgd door alleen het major versienummer (API-24)
+
+> "collectie" is een entiteittype (zelfstandig naamwoord) in meervoud (API-08)
+__ISSUE__: Hoe vertalen we entiteittype die in UGM in enkelvoud staan (t.b.v. StUF) naar meervoud (t.b.v. API's)?
+
+> uri-parameter "sleutel" moet voorkomen in parameters met "in: path"
+
+  bijvoorbeeld:
+  ```
+  /v1/entiteiten/{entiteitid}
+    (...)
+    parameters:
+      - in: path
+        name: entiteitid
+        (...)
+  ```
+
+## Operaties
+> alleen standaard http operaties worden ondersteund: GET, PUT, POST, PATCH en DELETE (API-06)
+
+## Responses
+> De volgende http-statuscodes worden altijd opgenomen: 400, 409, 410, 422, 500, 503 (API-51).
+
+__ISSUE__: Wat is het verschil (in situatie waarin je het gebruikt) tussen 409 en 422?
+
+> De reponse op een POST ondersteunt statuscodes 201, 405, 409
+
+__ISSUE__: Waarom is statuscode 415 niet opgenomen specifiek bij de POST, PUT en PATCH operaties (is niet relevant voor de andere operaties)
+
+> De reponse op een GET (lijst objecten) ondersteunt statuscodes 200
+
+> De reponse op een GET op sleutel ondersteunt statuscodes 200, 404
+
+__ISSUE__: Waarom is statuscode 406 niet opgenomen specifiek bij de GET operaties (is niet relevant voor de andere operaties)
+
+> De reponse op een PUT of PATCH ondersteunt statuscodes 200, 204, 404, 405, 409
+
+> De reponse op een DELETE ondersteunt statuscodes 200, 404, 405
+
+__ISSUE__: Waarom statuscode 200 en niet 201? Wordt er dan ooit een response body opgenomen bij een delete?
+
+> Als caching wordt ondersteund (header Etag en/of header Last-Modified), moet resonse code 304 zijn opgenomen.
+
+> Als belasting van de servers kan worden beperkt (headers X-Rate-Limit-Limit, X-Rate-Limit-Remaining en X-Rate-Limit-Reset zijn opgenomen), moet responsecode 429 zijn opgenomen.
+
+> Als authenticatie relevant is voor de service, moet statuscode 401 worden opgenomen.
+
+> ALs autorisatie van toepassing is op de service, moet statuscode 403
+
+## Headers
+> OAuth 2.0 headers zijn opgenomen, wanneer OAuth 2.0 als authenticatiemechanisme is gekozen voor de service.
+
+> Er is een Warning header (RFC 7234) opgenomen (API-25).
+
+> Wanneer in de responsebody geometrie is opgenomen, moet er een header "Content-Crs" zijn opgenomen (API-44).
+
+> Wanneer er een query-parameter page is opgenomen voor de request (er kan dus worden gepagineerd), moeten de headers X-Total-Count, X-Pagination-Count, X-Pagination-Page en X-Pagination-Limit zijn opgenomen (API-46).
+
+> Voor caching kan header Etag en/of header Last-Modified worden opgenomen.
+
+> Belasting van de servers kan worden beperkt door headers X-Rate-Limit-Limit, X-Rate-Limit-Remaining en X-Rate-Limit-Reset op te nemen (API-49).
+
+## Parameters
+> Als er een (of meerdere) n-op-n relatie is opgenomen in de response, moet parameter expand zijn opgenomen (API-10)
+
+> Parameters zijn elementen van het entiteittype (filters), of een van de standaard parameters expand, fields, sorteer, zoek, page.
+
+> Parameters die verwijzen naar een element (filters) zijn gedefinieerd in camelCase (API-30).
+
+> Een geografisch filter wordt via een POST end-point beschikbaar gemaakt (APO-40).
+Dus niet als een query parameter
+
+> Als er een path-parameter is gedefinieerd (in: path), dan moet die ook in het pad voorkomen in accolades.
+
+## Response content (200)
+> Veldnamen zijn gedefinieerd in camelCase (API-30).
+
+> Een JSON-response heeft geen omhullende envelop (API-32).
+
+  Er wordt dus geen element opgenomen voor het entiteittype (zoals in StUF wel gebruikelijk is).
+
+> Verschillende contentserialisaties kunnen worden ondersteund: JSON, GeoJSON, JSON+HAL, XML, enz.
+
+> In de JSON+HAL response content body is een element "\_links" opgenomen.
+Bij alle andere contentserialisaties (zoals gewoon JSON) is "\_links" dus niet opgenomen.
+
+> Wanneer er een query-parameter page is opgenomen voor de request (er kan dus worden gepagineerd), moeten de elementen "first", "prev", "next" en "last" in "\_links" zijn opgenomen.
+
+> Wanneer er een query-parameter expand is opgenomen voor de request, moeten bij de relaties naast het \_links property ook de properties van de relatie of gerelateerde worden opgenomen.
+
+__ISSUE__: Kunnen we aangeven of er historie moet worden worden opgenomen? Kan dat niet beter als element in het UGM worden toegevoegd i.p.v. ingenereren zoals voor StUF is gedaan?
+
+### Geometrie
+> Voor geometrie gebruiken we GeoJSON (API-38)
+
+> GeoJSON is onderdeel van de embedded resource in de JSON response (API-39).
+
+### Relaties
+__ISSUE__: Hoe gaan we om met relatie-entiteiten?
+__ISSUE__: Hoe gaan we ermee om als er geen relatie-entiteit is, maar wel historie op de relatie?
+
+## Response content (400 reeks statuscodes)
+> De JSON response content van een fout bestaat uit de elementen type, title, status, detail en instance.
+
+> De JSON response content bij een POST, PUT of PATCH met statuscode 400 bestaat uit de elementen type, title, status, invalid-params.


### PR DESCRIPTION
Aanzet gemaakt voor documenten met vertaalregels vanuit:
- DSO API strategie
- vertaling van BSM (UML) naar OAS